### PR TITLE
Implement color intensity scaling and color distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+
+*.png


### PR DESCRIPTION
Implements intensity scaling allowing for finer details of dimmer pictures. Based on the `fexp` method provided by [William Brodie-Tyrrell](https://www.brodie-tyrrell.org/bbrot/).