### PR TITLE
Add option to read raw PPM and re-scale its values for nicer images

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Leland Batey <lelandbatey@gmail.com>"]
 
 [dependencies]
 argparse = "*"
+regex = "0.2"
 image = "*"
 rand = "0.3"
 time = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,6 +291,7 @@ fn render_buddhabort(c: BuddhaConf) -> Vec<Img> {
                 if will_loop_forever(cn) {
                     continue;
                 }
+                let mut periods = HashMap::new();
                 for itercount in 0..tconf.max_iterations {
                     trajectory.length = itercount;
                     if escaped {
@@ -313,6 +314,17 @@ fn render_buddhabort(c: BuddhaConf) -> Vec<Img> {
                     }
                     if z.norm() > 2.0 {
                         escaped = true;
+                    }
+                    // Check if we've encountered this point before (useful for avoiding cyclical
+                    // but never ending z's). This bit of math is a fancy way of checking if
+                    // itercount is a power of 2
+                    if itercount & (itercount - 1) == 0 {
+                        let k = format!("{:?}", z);
+                        if periods.contains_key(&k) {
+                            //println!("found an existing z on iter {}, exiting", itercount);
+                            break;
+                        }
+                        periods.insert(k, itercount);
                     }
                 }
                 if escaped {


### PR DESCRIPTION
This PR adds a command line option to read-in a PPM with it's raw and unscaled brightness values and output several `.png` files, each with different brightness scaling formulas applied to the brightness of pixels in the input image.

Basically, if the actual `.png` image that's originally output by the software doesn't look all that good, you don't have to scale brightness values of that PNG to get a good image, instead you can re-scale the original values with this new mode. This leads to much higher quality images, especially dim ones without the detail for even Gimp to work with.